### PR TITLE
Next i18n example: use locale()

### DIFF
--- a/i18n-nextjs-contentful/localization-config.ts
+++ b/i18n-nextjs-contentful/localization-config.ts
@@ -5,6 +5,8 @@ import {
   Model,
   UpdateOperationField,
   ModelMap,
+  DataModel,
+  PageModel,
 } from '@stackbit/types';
 import { ContentfulContentSource } from '@stackbit/cms-contentful';
 import localization from 'utils/localization';
@@ -32,17 +34,24 @@ export class LocalizableContentfulContentSource extends ContentfulContentSource 
   }
 }
 
-export function markLocalizedModel(model: ModelWithSource) {
+type LocalizableModelWithSource = (DataModel | PageModel) & { srcType: string; srcProjectId: string };
+
+export function markLocalizedModel(model: ModelWithSource): ModelWithSource {
   if (!localization.nonLocalizedModels.includes(model.name)) {
+    model = model as LocalizableModelWithSource;
     return {
       ...model,
       localized: true,
+      locale: ({ document }) => {
+        return (document.fields['locale'] as DocumentStringLikeFieldNonLocalized)?.value;
+      },
     };
   } else {
     return model;
   }
 }
 
+/*
 export function mapLocalizedDocuments(documents: DocumentWithSource[]) {
   const documentLocale = (document: DocumentWithSource) => {
     const value = (document.fields?.locale as DocumentStringLikeFieldNonLocalized)?.value;
@@ -60,3 +69,4 @@ export function mapLocalizedDocuments(documents: DocumentWithSource[]) {
     return document;
   });
 }
+*/

--- a/i18n-nextjs-contentful/localization-config.ts
+++ b/i18n-nextjs-contentful/localization-config.ts
@@ -1,5 +1,4 @@
 import {
-  DocumentWithSource,
   ModelWithSource,
   DocumentStringLikeFieldNonLocalized,
   Model,
@@ -50,23 +49,3 @@ export function markLocalizedModel(model: ModelWithSource): ModelWithSource {
     return model;
   }
 }
-
-/*
-export function mapLocalizedDocuments(documents: DocumentWithSource[]) {
-  const documentLocale = (document: DocumentWithSource) => {
-    const value = (document.fields?.locale as DocumentStringLikeFieldNonLocalized)?.value;
-    return value && localization.locales.includes(value) ? value : null;
-  };
-
-  return documents.map((document) => {
-    if (!localization.nonLocalizedModels.includes(document.modelName)) {
-      const locale = documentLocale(document);
-      return {
-        ...document,
-        locale,
-      };
-    }
-    return document;
-  });
-}
-*/

--- a/i18n-nextjs-contentful/package-lock.json
+++ b/i18n-nextjs-contentful/package-lock.json
@@ -14,8 +14,8 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@stackbit/cms-contentful": "^0.3.0",
-        "@stackbit/types": "^0.4.0",
+        "@stackbit/cms-contentful": "^0.3.2",
+        "@stackbit/types": "^0.5.0",
         "@types/node": "^18.15.11",
         "@types/react": "18.0.32",
         "autoprefixer": "^10.4.8",
@@ -985,15 +985,15 @@
       "dev": true
     },
     "node_modules/@stackbit/cms-contentful": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.0.tgz",
-      "integrity": "sha512-i0DDgJ9UMZKKDZ+owmiAggMmHXxvV74r3+SFLdXGEkvjXTVyVBFG1R1wUmq52AqS9BfvrBX1+3rFENodzSFRHQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.2.tgz",
+      "integrity": "sha512-j7uJX/1B1+LEzkL4E8d7lDZCPwpyUjDzYNHElNIipO9K2ELGKAkgQLkaCyAj5RRaRZmgCEh2okbwq6LXLe5t0g==",
       "dev": true,
       "dependencies": {
         "@contentful/rich-text-types": "^15.11.1",
-        "@stackbit/cms-core": "0.3.0",
-        "@stackbit/types": "0.4.0",
-        "@stackbit/utils": "0.2.24",
+        "@stackbit/cms-core": "0.4.1",
+        "@stackbit/types": "0.5.0",
+        "@stackbit/utils": "0.2.25",
         "contentful": "^9.1.10",
         "contentful-management": "^7.51.4",
         "lodash": "^4.17.21"
@@ -1054,17 +1054,17 @@
       }
     },
     "node_modules/@stackbit/cms-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.3.0.tgz",
-      "integrity": "sha512-cezHgqp3x45yBzdcO2acSfZgv3+69q6P1ikJU6WuoU4NcZQx21f/rp9JtPUeRlMVf/QoGlKhiCeza0G7cEhhYw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.4.1.tgz",
+      "integrity": "sha512-04EFApUBXoumivI6tQd8cXjJZrSy8SPjrNAz/A3si9EWZWLPk7hH4rF44qhvS5NE/cesBTZhCau2bc2wmjsffg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.11.5",
         "@babel/traverse": "^7.11.5",
         "@iarna/toml": "^2.2.3",
-        "@stackbit/sdk": "0.4.0",
-        "@stackbit/types": "0.4.0",
-        "@stackbit/utils": "0.2.24",
+        "@stackbit/sdk": "0.4.1",
+        "@stackbit/types": "0.5.0",
+        "@stackbit/utils": "0.2.25",
         "chalk": "^4.0.1",
         "esm": "^3.2.25",
         "fs-extra": "^8.1.0",
@@ -1090,14 +1090,14 @@
       }
     },
     "node_modules/@stackbit/sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.4.0.tgz",
-      "integrity": "sha512-u8VXEVT/dv1qKgEWzAWpzkDEE9aTiViIbhX0qzo9RqqUhxTOnqHG/jr75c2kp8wAB68C/xahEc0V8cGwpuJL2g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.4.1.tgz",
+      "integrity": "sha512-Fs1MGvwJoWUo8A+9Hr0z62E1ZQ3acKeNTattduXnqa6SirhGr3VwUzQesllQbeu5mYPzNQfldhSz3NqmvCk3ow==",
       "dev": true,
       "dependencies": {
         "@octokit/rest": "^18.3.5",
-        "@stackbit/types": "0.4.0",
-        "@stackbit/utils": "0.2.24",
+        "@stackbit/types": "0.5.0",
+        "@stackbit/utils": "0.2.25",
         "acorn": "^8.2.4",
         "chokidar": "^3.5.3",
         "esbuild": "^0.14.42",
@@ -1165,15 +1165,15 @@
       }
     },
     "node_modules/@stackbit/types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.4.0.tgz",
-      "integrity": "sha512-CbFiBc7K8xkydjTdDC8zlki4iLd6Ma87xsQLb6iJRDFT3Njudo8QgCGzNUAvTsFS1h7hATIiV/n4G3TFI3U0Rw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.5.0.tgz",
+      "integrity": "sha512-sFQhxmmHRmowsxrZuzrE33Wgsmmcdc1JB7lrfPJE0D9kBHKPg76gdqahnCLcdMqacKlJVff21XKGriWO8mqcVw==",
       "dev": true
     },
     "node_modules/@stackbit/utils": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.24.tgz",
-      "integrity": "sha512-kfl/r8TPkeV3n1E0DwOjnuFZWimFhqacB6RrmtvPMughJe4a6E7C1hrYexYRg77xAkkUkb1ri8thZ/q2U2EOuQ==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.25.tgz",
+      "integrity": "sha512-LiFg35aNE6mxM60bLJtC8R1TKdTaA104k6TFZFG+kYiXZqto1TxhntdaibSqrb9k7EdtCMJcn3gtonf4zcESeA==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -7644,15 +7644,15 @@
       "dev": true
     },
     "@stackbit/cms-contentful": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.0.tgz",
-      "integrity": "sha512-i0DDgJ9UMZKKDZ+owmiAggMmHXxvV74r3+SFLdXGEkvjXTVyVBFG1R1wUmq52AqS9BfvrBX1+3rFENodzSFRHQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.2.tgz",
+      "integrity": "sha512-j7uJX/1B1+LEzkL4E8d7lDZCPwpyUjDzYNHElNIipO9K2ELGKAkgQLkaCyAj5RRaRZmgCEh2okbwq6LXLe5t0g==",
       "dev": true,
       "requires": {
         "@contentful/rich-text-types": "^15.11.1",
-        "@stackbit/cms-core": "0.3.0",
-        "@stackbit/types": "0.4.0",
-        "@stackbit/utils": "0.2.24",
+        "@stackbit/cms-core": "0.4.1",
+        "@stackbit/types": "0.5.0",
+        "@stackbit/utils": "0.2.25",
         "contentful": "^9.1.10",
         "contentful-management": "^7.51.4",
         "lodash": "^4.17.21"
@@ -7703,17 +7703,17 @@
       }
     },
     "@stackbit/cms-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.3.0.tgz",
-      "integrity": "sha512-cezHgqp3x45yBzdcO2acSfZgv3+69q6P1ikJU6WuoU4NcZQx21f/rp9JtPUeRlMVf/QoGlKhiCeza0G7cEhhYw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.4.1.tgz",
+      "integrity": "sha512-04EFApUBXoumivI6tQd8cXjJZrSy8SPjrNAz/A3si9EWZWLPk7hH4rF44qhvS5NE/cesBTZhCau2bc2wmjsffg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.11.5",
         "@babel/traverse": "^7.11.5",
         "@iarna/toml": "^2.2.3",
-        "@stackbit/sdk": "0.4.0",
-        "@stackbit/types": "0.4.0",
-        "@stackbit/utils": "0.2.24",
+        "@stackbit/sdk": "0.4.1",
+        "@stackbit/types": "0.5.0",
+        "@stackbit/utils": "0.2.25",
         "chalk": "^4.0.1",
         "esm": "^3.2.25",
         "fs-extra": "^8.1.0",
@@ -7738,14 +7738,14 @@
       }
     },
     "@stackbit/sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.4.0.tgz",
-      "integrity": "sha512-u8VXEVT/dv1qKgEWzAWpzkDEE9aTiViIbhX0qzo9RqqUhxTOnqHG/jr75c2kp8wAB68C/xahEc0V8cGwpuJL2g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.4.1.tgz",
+      "integrity": "sha512-Fs1MGvwJoWUo8A+9Hr0z62E1ZQ3acKeNTattduXnqa6SirhGr3VwUzQesllQbeu5mYPzNQfldhSz3NqmvCk3ow==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.3.5",
-        "@stackbit/types": "0.4.0",
-        "@stackbit/utils": "0.2.24",
+        "@stackbit/types": "0.5.0",
+        "@stackbit/utils": "0.2.25",
         "acorn": "^8.2.4",
         "chokidar": "^3.5.3",
         "esbuild": "^0.14.42",
@@ -7804,15 +7804,15 @@
       }
     },
     "@stackbit/types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.4.0.tgz",
-      "integrity": "sha512-CbFiBc7K8xkydjTdDC8zlki4iLd6Ma87xsQLb6iJRDFT3Njudo8QgCGzNUAvTsFS1h7hATIiV/n4G3TFI3U0Rw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.5.0.tgz",
+      "integrity": "sha512-sFQhxmmHRmowsxrZuzrE33Wgsmmcdc1JB7lrfPJE0D9kBHKPg76gdqahnCLcdMqacKlJVff21XKGriWO8mqcVw==",
       "dev": true
     },
     "@stackbit/utils": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.24.tgz",
-      "integrity": "sha512-kfl/r8TPkeV3n1E0DwOjnuFZWimFhqacB6RrmtvPMughJe4a6E7C1hrYexYRg77xAkkUkb1ri8thZ/q2U2EOuQ==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.25.tgz",
+      "integrity": "sha512-LiFg35aNE6mxM60bLJtC8R1TKdTaA104k6TFZFG+kYiXZqto1TxhntdaibSqrb9k7EdtCMJcn3gtonf4zcESeA==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",

--- a/i18n-nextjs-contentful/package-lock.json
+++ b/i18n-nextjs-contentful/package-lock.json
@@ -14,8 +14,9 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@stackbit/cms-contentful": "^0.2.1",
-        "@stackbit/types": "^0.3.0",
+        "@stackbit/cms-contentful": "^0.3.0",
+        "@stackbit/types": "^0.4.0",
+        "@types/node": "^18.15.11",
         "@types/react": "18.0.32",
         "autoprefixer": "^10.4.8",
         "contentful-import": "^8.5.34",
@@ -295,6 +296,22 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -451,9 +468,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -483,20 +500,26 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@next/env": {
       "version": "13.2.4",
@@ -962,25 +985,19 @@
       "dev": true
     },
     "node_modules/@stackbit/cms-contentful": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.2.1.tgz",
-      "integrity": "sha512-J7V0X+oApVmoAzJGjolhm1xr63ydxPub2WXkIXtk+LB2G+xothpUxwaxZ+csJcoPtAMySAT4KdwMOE7lE920xA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.0.tgz",
+      "integrity": "sha512-i0DDgJ9UMZKKDZ+owmiAggMmHXxvV74r3+SFLdXGEkvjXTVyVBFG1R1wUmq52AqS9BfvrBX1+3rFENodzSFRHQ==",
       "dev": true,
       "dependencies": {
         "@contentful/rich-text-types": "^15.11.1",
-        "@stackbit/cms-core": "0.2.1",
-        "@stackbit/types": "0.2.0-staging.0",
-        "@stackbit/utils": "0.2.23",
+        "@stackbit/cms-core": "0.3.0",
+        "@stackbit/types": "0.4.0",
+        "@stackbit/utils": "0.2.24",
         "contentful": "^9.1.10",
         "contentful-management": "^7.51.4",
         "lodash": "^4.17.21"
       }
-    },
-    "node_modules/@stackbit/cms-contentful/node_modules/@stackbit/types": {
-      "version": "0.2.0-staging.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.2.0-staging.0.tgz",
-      "integrity": "sha512-H8v/Ie+AJgYxg1lxXF9ioh8K2GU69MZXCsEqpyh363y/Zu0ktraw/cHdGGppgWN+/wIkViJ5WC6k7o524fEMEA==",
-      "dev": true
     },
     "node_modules/@stackbit/cms-contentful/node_modules/axios": {
       "version": "0.21.4",
@@ -1037,17 +1054,17 @@
       }
     },
     "node_modules/@stackbit/cms-core": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.2.1.tgz",
-      "integrity": "sha512-Fwf/XWhh7YWONkfBc6+Y8zBxo9VmAwgdz526LkftdvGMa+gncnHCWKCbEUaqqR6mXmhpF62slYzM2eI2aK1deQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.3.0.tgz",
+      "integrity": "sha512-cezHgqp3x45yBzdcO2acSfZgv3+69q6P1ikJU6WuoU4NcZQx21f/rp9JtPUeRlMVf/QoGlKhiCeza0G7cEhhYw==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.11.5",
         "@babel/traverse": "^7.11.5",
         "@iarna/toml": "^2.2.3",
-        "@stackbit/sdk": "0.3.26",
-        "@stackbit/types": "0.2.0-staging.0",
-        "@stackbit/utils": "0.2.23",
+        "@stackbit/sdk": "0.4.0",
+        "@stackbit/types": "0.4.0",
+        "@stackbit/utils": "0.2.24",
         "chalk": "^4.0.1",
         "esm": "^3.2.25",
         "fs-extra": "^8.1.0",
@@ -1063,12 +1080,6 @@
         "uuid": "^9.0.0"
       }
     },
-    "node_modules/@stackbit/cms-core/node_modules/@stackbit/types": {
-      "version": "0.2.0-staging.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.2.0-staging.0.tgz",
-      "integrity": "sha512-H8v/Ie+AJgYxg1lxXF9ioh8K2GU69MZXCsEqpyh363y/Zu0ktraw/cHdGGppgWN+/wIkViJ5WC6k7o524fEMEA==",
-      "dev": true
-    },
     "node_modules/@stackbit/cms-core/node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -1079,14 +1090,14 @@
       }
     },
     "node_modules/@stackbit/sdk": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.3.26.tgz",
-      "integrity": "sha512-c/vPv5deVmghYhTqvjPS5BNm5NfaNdLbbadnLotrFSMtJHv/VT7WGKyDtKrmRxiYvZZhb2rEvIrORwq/kXardA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-u8VXEVT/dv1qKgEWzAWpzkDEE9aTiViIbhX0qzo9RqqUhxTOnqHG/jr75c2kp8wAB68C/xahEc0V8cGwpuJL2g==",
       "dev": true,
       "dependencies": {
         "@octokit/rest": "^18.3.5",
-        "@stackbit/types": "0.2.0-staging.0",
-        "@stackbit/utils": "0.2.23",
+        "@stackbit/types": "0.4.0",
+        "@stackbit/utils": "0.2.24",
         "acorn": "^8.2.4",
         "chokidar": "^3.5.3",
         "esbuild": "^0.14.42",
@@ -1098,12 +1109,6 @@
         "moment": "^2.29.1",
         "semver": "^7.3.5"
       }
-    },
-    "node_modules/@stackbit/sdk/node_modules/@stackbit/types": {
-      "version": "0.2.0-staging.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.2.0-staging.0.tgz",
-      "integrity": "sha512-H8v/Ie+AJgYxg1lxXF9ioh8K2GU69MZXCsEqpyh363y/Zu0ktraw/cHdGGppgWN+/wIkViJ5WC6k7o524fEMEA==",
-      "dev": true
     },
     "node_modules/@stackbit/sdk/node_modules/argparse": {
       "version": "2.0.1",
@@ -1160,15 +1165,15 @@
       }
     },
     "node_modules/@stackbit/types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.3.0.tgz",
-      "integrity": "sha512-Y89cVRYdYworOfg5t/35IiZ2YDxQ87Mns2wws4deiWWVSUl+cQAmfl67mJI0QtIzNTZk/02PGsEasLHMBqAw7Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.4.0.tgz",
+      "integrity": "sha512-CbFiBc7K8xkydjTdDC8zlki4iLd6Ma87xsQLb6iJRDFT3Njudo8QgCGzNUAvTsFS1h7hATIiV/n4G3TFI3U0Rw==",
       "dev": true
     },
     "node_modules/@stackbit/utils": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.23.tgz",
-      "integrity": "sha512-CN3DgWfiNMmMea28w8+KWd63aHZF8knsB+GVIUNPfxrOrp1t5J3NtOcKFGruOnuwFw7IE10aKZQMslK1X5oD9Q==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.24.tgz",
+      "integrity": "sha512-kfl/r8TPkeV3n1E0DwOjnuFZWimFhqacB6RrmtvPMughJe4a6E7C1hrYexYRg77xAkkUkb1ri8thZ/q2U2EOuQ==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -1250,6 +1255,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -2562,6 +2573,38 @@
         "esbuild-windows-arm64": "0.14.54"
       }
     },
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/esbuild-darwin-64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
@@ -2573,6 +2616,278 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -6852,6 +7167,13 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
     },
+    "@esbuild/linux-loong64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -6967,9 +7289,9 @@
       "dev": true
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
@@ -6990,19 +7312,27 @@
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      },
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+          "dev": true
+        }
       }
     },
     "@next/env": {
@@ -7314,26 +7644,20 @@
       "dev": true
     },
     "@stackbit/cms-contentful": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.2.1.tgz",
-      "integrity": "sha512-J7V0X+oApVmoAzJGjolhm1xr63ydxPub2WXkIXtk+LB2G+xothpUxwaxZ+csJcoPtAMySAT4KdwMOE7lE920xA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.0.tgz",
+      "integrity": "sha512-i0DDgJ9UMZKKDZ+owmiAggMmHXxvV74r3+SFLdXGEkvjXTVyVBFG1R1wUmq52AqS9BfvrBX1+3rFENodzSFRHQ==",
       "dev": true,
       "requires": {
         "@contentful/rich-text-types": "^15.11.1",
-        "@stackbit/cms-core": "0.2.1",
-        "@stackbit/types": "0.2.0-staging.0",
-        "@stackbit/utils": "0.2.23",
+        "@stackbit/cms-core": "0.3.0",
+        "@stackbit/types": "0.4.0",
+        "@stackbit/utils": "0.2.24",
         "contentful": "^9.1.10",
         "contentful-management": "^7.51.4",
         "lodash": "^4.17.21"
       },
       "dependencies": {
-        "@stackbit/types": {
-          "version": "0.2.0-staging.0",
-          "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.2.0-staging.0.tgz",
-          "integrity": "sha512-H8v/Ie+AJgYxg1lxXF9ioh8K2GU69MZXCsEqpyh363y/Zu0ktraw/cHdGGppgWN+/wIkViJ5WC6k7o524fEMEA==",
-          "dev": true
-        },
         "axios": {
           "version": "0.21.4",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -7379,17 +7703,17 @@
       }
     },
     "@stackbit/cms-core": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.2.1.tgz",
-      "integrity": "sha512-Fwf/XWhh7YWONkfBc6+Y8zBxo9VmAwgdz526LkftdvGMa+gncnHCWKCbEUaqqR6mXmhpF62slYzM2eI2aK1deQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.3.0.tgz",
+      "integrity": "sha512-cezHgqp3x45yBzdcO2acSfZgv3+69q6P1ikJU6WuoU4NcZQx21f/rp9JtPUeRlMVf/QoGlKhiCeza0G7cEhhYw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.11.5",
         "@babel/traverse": "^7.11.5",
         "@iarna/toml": "^2.2.3",
-        "@stackbit/sdk": "0.3.26",
-        "@stackbit/types": "0.2.0-staging.0",
-        "@stackbit/utils": "0.2.23",
+        "@stackbit/sdk": "0.4.0",
+        "@stackbit/types": "0.4.0",
+        "@stackbit/utils": "0.2.24",
         "chalk": "^4.0.1",
         "esm": "^3.2.25",
         "fs-extra": "^8.1.0",
@@ -7405,12 +7729,6 @@
         "uuid": "^9.0.0"
       },
       "dependencies": {
-        "@stackbit/types": {
-          "version": "0.2.0-staging.0",
-          "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.2.0-staging.0.tgz",
-          "integrity": "sha512-H8v/Ie+AJgYxg1lxXF9ioh8K2GU69MZXCsEqpyh363y/Zu0ktraw/cHdGGppgWN+/wIkViJ5WC6k7o524fEMEA==",
-          "dev": true
-        },
         "uuid": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -7420,14 +7738,14 @@
       }
     },
     "@stackbit/sdk": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.3.26.tgz",
-      "integrity": "sha512-c/vPv5deVmghYhTqvjPS5BNm5NfaNdLbbadnLotrFSMtJHv/VT7WGKyDtKrmRxiYvZZhb2rEvIrORwq/kXardA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-u8VXEVT/dv1qKgEWzAWpzkDEE9aTiViIbhX0qzo9RqqUhxTOnqHG/jr75c2kp8wAB68C/xahEc0V8cGwpuJL2g==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.3.5",
-        "@stackbit/types": "0.2.0-staging.0",
-        "@stackbit/utils": "0.2.23",
+        "@stackbit/types": "0.4.0",
+        "@stackbit/utils": "0.2.24",
         "acorn": "^8.2.4",
         "chokidar": "^3.5.3",
         "esbuild": "^0.14.42",
@@ -7440,12 +7758,6 @@
         "semver": "^7.3.5"
       },
       "dependencies": {
-        "@stackbit/types": {
-          "version": "0.2.0-staging.0",
-          "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.2.0-staging.0.tgz",
-          "integrity": "sha512-H8v/Ie+AJgYxg1lxXF9ioh8K2GU69MZXCsEqpyh363y/Zu0ktraw/cHdGGppgWN+/wIkViJ5WC6k7o524fEMEA==",
-          "dev": true
-        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -7492,15 +7804,15 @@
       }
     },
     "@stackbit/types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.3.0.tgz",
-      "integrity": "sha512-Y89cVRYdYworOfg5t/35IiZ2YDxQ87Mns2wws4deiWWVSUl+cQAmfl67mJI0QtIzNTZk/02PGsEasLHMBqAw7Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.4.0.tgz",
+      "integrity": "sha512-CbFiBc7K8xkydjTdDC8zlki4iLd6Ma87xsQLb6iJRDFT3Njudo8QgCGzNUAvTsFS1h7hATIiV/n4G3TFI3U0Rw==",
       "dev": true
     },
     "@stackbit/utils": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.23.tgz",
-      "integrity": "sha512-CN3DgWfiNMmMea28w8+KWd63aHZF8knsB+GVIUNPfxrOrp1t5J3NtOcKFGruOnuwFw7IE10aKZQMslK1X5oD9Q==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.24.tgz",
+      "integrity": "sha512-kfl/r8TPkeV3n1E0DwOjnuFZWimFhqacB6RrmtvPMughJe4a6E7C1hrYexYRg77xAkkUkb1ri8thZ/q2U2EOuQ==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
@@ -7573,6 +7885,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
     "@types/prop-types": {
@@ -8548,10 +8866,143 @@
         "esbuild-windows-arm64": "0.14.54"
       }
     },
+    "esbuild-android-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+      "dev": true,
+      "optional": true
+    },
     "esbuild-darwin-64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
       "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
       "dev": true,
       "optional": true
     },

--- a/i18n-nextjs-contentful/package.json
+++ b/i18n-nextjs-contentful/package.json
@@ -14,8 +14,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@stackbit/cms-contentful": "^0.3.0",
-    "@stackbit/types": "^0.4.0",
+    "@stackbit/cms-contentful": "^0.3.2",
+    "@stackbit/types": "^0.5.0",
     "@types/node": "^18.15.11",
     "@types/react": "18.0.32",
     "autoprefixer": "^10.4.8",

--- a/i18n-nextjs-contentful/package.json
+++ b/i18n-nextjs-contentful/package.json
@@ -14,8 +14,9 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@stackbit/cms-contentful": "^0.2.1",
-    "@stackbit/types": "^0.3.0",
+    "@stackbit/cms-contentful": "^0.3.0",
+    "@stackbit/types": "^0.4.0",
+    "@types/node": "^18.15.11",
     "@types/react": "18.0.32",
     "autoprefixer": "^10.4.8",
     "contentful-import": "^8.5.34",

--- a/i18n-nextjs-contentful/stackbit.config.ts
+++ b/i18n-nextjs-contentful/stackbit.config.ts
@@ -10,7 +10,6 @@ import {
 } from 'localization-config';
 import localization from 'utils/localization';
 import { normalizeSlug, PAGE_TYPES, SITE_CONFIG_TYPE } from 'utils/common';
-//import { ContentfulContentSource } from '@stackbit/cms-contentful';
 
 const contentSource = new LocalizableContentfulContentSource({
   spaceId: process.env.CONTENTFUL_SPACE_ID!,
@@ -54,10 +53,6 @@ const config = defineStackbitConfig({
     models = models.map(markLocalizedModel);
     return models;
   },
-  /*mapDocuments: ({ documents }) => {
-    documents = mapLocalizedDocuments(documents);
-    return documents;
-  },*/
   siteMap: ({ documents }) => {
     const pages = documents.filter((doc) => PAGE_TYPES.includes(doc.modelName));
 
@@ -66,7 +61,8 @@ const config = defineStackbitConfig({
       if (!slug) return null;
 
       slug = normalizeSlug(slug);
-      const slugPrefix = document.locale !== localization.defaultLocale ? '/' + document.locale : '';
+      const nonDefaultLocale = document.locale && document.locale !== localization.defaultLocale;
+      const slugPrefix = nonDefaultLocale ? '/' + document.locale : '';
       return {
         urlPath: slugPrefix + slug,
         document,

--- a/i18n-nextjs-contentful/stackbit.config.ts
+++ b/i18n-nextjs-contentful/stackbit.config.ts
@@ -4,15 +4,19 @@ import {
   ModelExtension,
   SiteMapEntry,
 } from '@stackbit/types';
-import { LocalizableContentfulContentSource, mapLocalizedDocuments, markLocalizedModel } from 'localization-config';
+import {
+  LocalizableContentfulContentSource,
+  markLocalizedModel /*, mapLocalizedDocuments*/,
+} from 'localization-config';
 import localization from 'utils/localization';
 import { normalizeSlug, PAGE_TYPES, SITE_CONFIG_TYPE } from 'utils/common';
+//import { ContentfulContentSource } from '@stackbit/cms-contentful';
 
 const contentSource = new LocalizableContentfulContentSource({
-  spaceId: process.env.CONTENTFUL_SPACE_ID,
+  spaceId: process.env.CONTENTFUL_SPACE_ID!,
   environment: process.env.CONTENTFUL_ENVIRONMENT || 'master',
-  previewToken: process.env.CONTENTFUL_PREVIEW_TOKEN,
-  accessToken: process.env.CONTENTFUL_MANAGEMENT_TOKEN,
+  previewToken: process.env.CONTENTFUL_PREVIEW_TOKEN!,
+  accessToken: process.env.CONTENTFUL_MANAGEMENT_TOKEN!,
 });
 
 const pageModelExtensions: ModelExtension[] = PAGE_TYPES.map((name) => {
@@ -50,10 +54,10 @@ const config = defineStackbitConfig({
     models = models.map(markLocalizedModel);
     return models;
   },
-  mapDocuments: ({ documents }) => {
+  /*mapDocuments: ({ documents }) => {
     documents = mapLocalizedDocuments(documents);
     return documents;
-  },
+  },*/
   siteMap: ({ documents }) => {
     const pages = documents.filter((doc) => PAGE_TYPES.includes(doc.modelName));
 


### PR DESCRIPTION
* Bump CSI package versions to support `locale()`
* Replace `mapDocuments` hook with `locale()`
* Fully removing the need for a class extending `ContentfulContentSource` requires documents hooks - when these are released.