### PR TITLE
updated dependencies

### DIFF
--- a/i18n-nextjs-contentful/package-lock.json
+++ b/i18n-nextjs-contentful/package-lock.json
@@ -14,9 +14,9 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@stackbit/cms-contentful": "^0.3.8",
-        "@stackbit/types": "^0.6.2",
-        "@types/node": "^20.1.3",
+        "@stackbit/cms-contentful": "^0.3.9",
+        "@stackbit/types": "^0.7.0",
+        "@types/node": "^20.2.0",
         "@types/react": "18.2.6",
         "autoprefixer": "^10.4.14",
         "contentful-import": "^8.5.54",
@@ -937,15 +937,15 @@
       "dev": true
     },
     "node_modules/@stackbit/cms-contentful": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.8.tgz",
-      "integrity": "sha512-Tmvjg2/Q1UzZkLD/yjqoNuK3eAoWcDa8D7qvQ/ZbsOaK+u5xch/Q/ZPpXB1K1/BXSZRGh05HyaJfEHnVZ5/PPg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.9.tgz",
+      "integrity": "sha512-GBQr+TLBs/G5Dz+Z3kaNIVPf/fxpeFoHBXaD2jQrPUf4McNcbIyvctodI9sHNHkDEvFpYaJcRvhBQZfbJeXyLg==",
       "dev": true,
       "dependencies": {
         "@contentful/rich-text-types": "^15.11.1",
-        "@stackbit/cms-core": "0.5.2",
-        "@stackbit/types": "0.6.2",
-        "@stackbit/utils": "0.2.29",
+        "@stackbit/cms-core": "0.6.0",
+        "@stackbit/types": "0.7.0",
+        "@stackbit/utils": "0.2.30",
         "contentful": "^9.1.10",
         "contentful-management": "^7.51.4",
         "lodash": "^4.17.21"
@@ -1006,17 +1006,17 @@
       }
     },
     "node_modules/@stackbit/cms-core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.5.2.tgz",
-      "integrity": "sha512-nQHpWzw+jwNPY87RTtynZ1lrJw1AKn4QQEccI0m0M6vRhOedAnHyqlW63T8CX/6eazwBBaAM3v7jiBtFB4//3Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.6.0.tgz",
+      "integrity": "sha512-BFx11EPxff/3D7bpNNRCkbVC9ksmRyoI4rVhRrQ/X62aj38J8DovTa3xMi4QG/PElt52wV4Vsjn8e8BSuH2MSQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.11.5",
         "@babel/traverse": "^7.11.5",
         "@iarna/toml": "^2.2.3",
-        "@stackbit/sdk": "0.5.2",
-        "@stackbit/types": "0.6.2",
-        "@stackbit/utils": "0.2.29",
+        "@stackbit/sdk": "0.5.3",
+        "@stackbit/types": "0.7.0",
+        "@stackbit/utils": "0.2.30",
         "chalk": "^4.0.1",
         "esm": "^3.2.25",
         "fs-extra": "^8.1.0",
@@ -1033,14 +1033,14 @@
       }
     },
     "node_modules/@stackbit/sdk": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.2.tgz",
-      "integrity": "sha512-pNn8gDFw5t3Cw05Q5yo5lQ7vCCXlbG8o13cyihJqTCLflrIf+Ne78MVIfoMaLvb5RHMz9CJ3W6163v+ATdCR3g==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.3.tgz",
+      "integrity": "sha512-GfGfUjzRUjZEgDfWdB7hSWGKCdZLNHyRhkdOIu1VtSkJZuEVQ5S+eA7MxyttPLVhytzSiHGVOL/KHRS0bQ1LdQ==",
       "dev": true,
       "dependencies": {
         "@octokit/rest": "^18.3.5",
-        "@stackbit/types": "0.6.2",
-        "@stackbit/utils": "0.2.29",
+        "@stackbit/types": "0.7.0",
+        "@stackbit/utils": "0.2.30",
         "acorn": "^8.2.4",
         "chokidar": "^3.5.3",
         "esbuild": "^0.14.42",
@@ -1108,15 +1108,15 @@
       }
     },
     "node_modules/@stackbit/types": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.6.2.tgz",
-      "integrity": "sha512-wA0B2Sfygj1YL5R0exuzzn3nB2FouxPDoxB0ImSy7TzsCO7JO1eXtTsDDAf81yRDlsGo2rIHIb5hfwQK4Jg7Kg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.7.0.tgz",
+      "integrity": "sha512-66ggCpiA32mxKtxOzBhyduN4Ea27+KsbOuKp6n9wZjQ7Z7MvTo3NO5FE4qC3nZBiZjaTafSGLxxi2bFsN0bTxQ==",
       "dev": true
     },
     "node_modules/@stackbit/utils": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.29.tgz",
-      "integrity": "sha512-cmbbtNkfbCVcA+pye9LWPCzKKueTHgHnERzaBef2cxpfbESjFSt2HBOUTyAEug1QEyV9FMjYPVBRX8HxwVzMdw==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.30.tgz",
+      "integrity": "sha512-lb/GuRbiYgZXzAAvYwwGnSn8QBfWTOzVUugDVuoKmU4/Rb8Tt1N9sCPEBhRy4Yh7y8liB1RMXVYg4x9LB1Mgaw==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -1201,9 +1201,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.1.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.3.tgz",
-      "integrity": "sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==",
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.0.tgz",
+      "integrity": "sha512-3iD2jaCCziTx04uudpJKwe39QxXgSUnpxXSvRQjRvHPxFQfmfP4NXIm/NURVeNlTCc+ru4WqjYGTmpXrW9uMlw==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -7649,15 +7649,15 @@
       "dev": true
     },
     "@stackbit/cms-contentful": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.8.tgz",
-      "integrity": "sha512-Tmvjg2/Q1UzZkLD/yjqoNuK3eAoWcDa8D7qvQ/ZbsOaK+u5xch/Q/ZPpXB1K1/BXSZRGh05HyaJfEHnVZ5/PPg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-contentful/-/cms-contentful-0.3.9.tgz",
+      "integrity": "sha512-GBQr+TLBs/G5Dz+Z3kaNIVPf/fxpeFoHBXaD2jQrPUf4McNcbIyvctodI9sHNHkDEvFpYaJcRvhBQZfbJeXyLg==",
       "dev": true,
       "requires": {
         "@contentful/rich-text-types": "^15.11.1",
-        "@stackbit/cms-core": "0.5.2",
-        "@stackbit/types": "0.6.2",
-        "@stackbit/utils": "0.2.29",
+        "@stackbit/cms-core": "0.6.0",
+        "@stackbit/types": "0.7.0",
+        "@stackbit/utils": "0.2.30",
         "contentful": "^9.1.10",
         "contentful-management": "^7.51.4",
         "lodash": "^4.17.21"
@@ -7708,17 +7708,17 @@
       }
     },
     "@stackbit/cms-core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.5.2.tgz",
-      "integrity": "sha512-nQHpWzw+jwNPY87RTtynZ1lrJw1AKn4QQEccI0m0M6vRhOedAnHyqlW63T8CX/6eazwBBaAM3v7jiBtFB4//3Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.6.0.tgz",
+      "integrity": "sha512-BFx11EPxff/3D7bpNNRCkbVC9ksmRyoI4rVhRrQ/X62aj38J8DovTa3xMi4QG/PElt52wV4Vsjn8e8BSuH2MSQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.11.5",
         "@babel/traverse": "^7.11.5",
         "@iarna/toml": "^2.2.3",
-        "@stackbit/sdk": "0.5.2",
-        "@stackbit/types": "0.6.2",
-        "@stackbit/utils": "0.2.29",
+        "@stackbit/sdk": "0.5.3",
+        "@stackbit/types": "0.7.0",
+        "@stackbit/utils": "0.2.30",
         "chalk": "^4.0.1",
         "esm": "^3.2.25",
         "fs-extra": "^8.1.0",
@@ -7735,14 +7735,14 @@
       }
     },
     "@stackbit/sdk": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.2.tgz",
-      "integrity": "sha512-pNn8gDFw5t3Cw05Q5yo5lQ7vCCXlbG8o13cyihJqTCLflrIf+Ne78MVIfoMaLvb5RHMz9CJ3W6163v+ATdCR3g==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.3.tgz",
+      "integrity": "sha512-GfGfUjzRUjZEgDfWdB7hSWGKCdZLNHyRhkdOIu1VtSkJZuEVQ5S+eA7MxyttPLVhytzSiHGVOL/KHRS0bQ1LdQ==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.3.5",
-        "@stackbit/types": "0.6.2",
-        "@stackbit/utils": "0.2.29",
+        "@stackbit/types": "0.7.0",
+        "@stackbit/utils": "0.2.30",
         "acorn": "^8.2.4",
         "chokidar": "^3.5.3",
         "esbuild": "^0.14.42",
@@ -7801,15 +7801,15 @@
       }
     },
     "@stackbit/types": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.6.2.tgz",
-      "integrity": "sha512-wA0B2Sfygj1YL5R0exuzzn3nB2FouxPDoxB0ImSy7TzsCO7JO1eXtTsDDAf81yRDlsGo2rIHIb5hfwQK4Jg7Kg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.7.0.tgz",
+      "integrity": "sha512-66ggCpiA32mxKtxOzBhyduN4Ea27+KsbOuKp6n9wZjQ7Z7MvTo3NO5FE4qC3nZBiZjaTafSGLxxi2bFsN0bTxQ==",
       "dev": true
     },
     "@stackbit/utils": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.29.tgz",
-      "integrity": "sha512-cmbbtNkfbCVcA+pye9LWPCzKKueTHgHnERzaBef2cxpfbESjFSt2HBOUTyAEug1QEyV9FMjYPVBRX8HxwVzMdw==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.30.tgz",
+      "integrity": "sha512-lb/GuRbiYgZXzAAvYwwGnSn8QBfWTOzVUugDVuoKmU4/Rb8Tt1N9sCPEBhRy4Yh7y8liB1RMXVYg4x9LB1Mgaw==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
@@ -7885,9 +7885,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.1.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.3.tgz",
-      "integrity": "sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==",
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.0.tgz",
+      "integrity": "sha512-3iD2jaCCziTx04uudpJKwe39QxXgSUnpxXSvRQjRvHPxFQfmfP4NXIm/NURVeNlTCc+ru4WqjYGTmpXrW9uMlw==",
       "dev": true
     },
     "@types/prop-types": {

--- a/i18n-nextjs-contentful/package.json
+++ b/i18n-nextjs-contentful/package.json
@@ -14,9 +14,9 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@stackbit/cms-contentful": "^0.3.8",
-    "@stackbit/types": "^0.6.2",
-    "@types/node": "^20.1.3",
+    "@stackbit/cms-contentful": "^0.3.9",
+    "@stackbit/types": "^0.7.0",
+    "@types/node": "^20.2.0",
     "@types/react": "18.2.6",
     "autoprefixer": "^10.4.14",
     "contentful-import": "^8.5.54",


### PR DESCRIPTION
Updated dependencies for the **i18n-nextjs-contentful** example:
- `@stackbit/cms-contentful` to v0.3.9
- `@stackbit/types` to v0.7.0
- `@types/node` to v20.2.0