### PR TITLE
[tutorial-html-json] Refactor recursive fs.watch to use node-watch

### DIFF
--- a/tutorial-html-json/package-lock.json
+++ b/tutorial-html-json/package-lock.json
@@ -12,6 +12,7 @@
                 "ejs": "^3.1.8",
                 "fast-glob": "^3.2.12",
                 "live-server": "^1.2.2",
+                "node-watch": "^0.7.4",
                 "prettier": "^2.8.4"
             }
         },
@@ -1673,6 +1674,15 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-watch": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.4.tgz",
+            "integrity": "sha512-RinNxoz4W1cep1b928fuFhvAQ5ag/+1UlMDV7rbyGthBIgsiEouS4kvRayvvboxii4m8eolKOIBo3OjDqbc+uQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/normalize-path": {
@@ -4151,6 +4161,12 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "dev": true
+        },
+        "node-watch": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.4.tgz",
+            "integrity": "sha512-RinNxoz4W1cep1b928fuFhvAQ5ag/+1UlMDV7rbyGthBIgsiEouS4kvRayvvboxii4m8eolKOIBo3OjDqbc+uQ==",
             "dev": true
         },
         "normalize-path": {

--- a/tutorial-html-json/package.json
+++ b/tutorial-html-json/package.json
@@ -12,6 +12,10 @@
         "ejs": "^3.1.8",
         "fast-glob": "^3.2.12",
         "live-server": "^1.2.2",
+        "node-watch": "^0.7.4",
         "prettier": "^2.8.4"
+    },
+    "engines": {
+        "node": ">=18"
     }
 }


### PR DESCRIPTION
This PR replaces the native `fs.watch()` with [node-watch](https://www.npmjs.com/package/node-watch) in order to run successfully on Node 18+ since watching recursively was deprecated. 